### PR TITLE
Support for Anchor Point on iOS

### DIFF
--- a/lib/ActionSheetIOS.js
+++ b/lib/ActionSheetIOS.js
@@ -7,7 +7,8 @@ const optionNames = [
 	'options', 
 	'tintColor',
 	'cancelButtonIndex', 
-	'destructiveButtonIndex'
+	'destructiveButtonIndex',
+	'anchor'
 ]
 
 
@@ -31,7 +32,7 @@ class ActionSheet extends React.Component {
 	show() {
 		let props = this.props;
     let options = optionNames.reduce((obj, name, index) => {
-        if (typeof props[name] !== 'undefined') obj[name] = props[name]
+        if (typeof props[name] !== 'undefined' && props[name] !== null) obj[name] = props[name]
         return obj
     }, {})
 		ActionSheetIOS.showActionSheetWithOptions(options, props.onPress)
@@ -49,7 +50,8 @@ ActionSheet.propTypes = {
 	tintColor: PropTypes.string,
 	cancelButtonIndex: PropTypes.number,
 	destructiveButtonIndex: PropTypes.number,
-	onPress: PropTypes.func
+	onPress: PropTypes.func,
+	anchor: PropTypes.object
 }
 
 ActionSheet.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-actionsheet",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Cross platform ActionSheet. This component implements a custom ActionSheet  and provides the same way to drawing it on the defferent platforms(iOS and Android). Actually, In order to keep the best effect, it still uses the ActionSheetIOS on iOS.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Instead of the ActionSheet always showing up in the center on iPads, this allows an ‘anchor’ prop to be passed in, which should be the node from RN’s findHostNode(ref), where ref is the reference of the anchor view.  This has been tested on an iPad.