### PR TITLE
Fix necessity of double click for focus

### DIFF
--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -198,7 +198,7 @@ class ActionSheet extends React.Component {
           >
             {this._renderTitle()}
             {this._renderMessage()}
-            <ScrollView scrollEnabled={this.scrollEnabled}>{this._renderOptions()}</ScrollView>
+            <ScrollView scrollEnabled={this.scrollEnabled} keyboardShouldPersistTaps='always'>{this._renderOptions()}</ScrollView>
             {this._renderCancelButton()}
           </Animated.View>
         </View>


### PR DESCRIPTION
On android sometimes it's needs a double tap on actionsheet to activate button.