### PR TITLE
fix cancel

### DIFF
--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -59,9 +59,7 @@ class ActionSheet extends React.Component {
     const { cancelButtonIndex } = this.props
     // 保持和 ActionSheetIOS 一致，
     // 未设置 cancelButtonIndex 时，点击背景不隐藏 ActionSheet
-    if (utils.isset(cancelButtonIndex)) {
-      this.hide(cancelButtonIndex)
-    }
+    this.hide(cancelButtonIndex)
   }
 
   _showSheet = () => {
@@ -186,6 +184,7 @@ class ActionSheet extends React.Component {
         onRequestClose={this._cancel}
       >
         <View style={[styles.wrapper]}>
+          {this.props.children}
           <Text
             style={[styles.overlay]}
             onPress={this._cancel}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-actionsheet",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Cross platform ActionSheet. This component implements a custom ActionSheet  and provides the same way to drawing it on the defferent platforms(iOS and Android). Actually, In order to keep the best effect, it still uses the ActionSheetIOS on iOS.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
we needed custom cancel button that should appear on top of layout. We didnt want to add cancel button as option. Currently, when there's no cancel button defined, clicking layout doesn't do anything and user is stucked at screen. So this fixes the issue , it closes the modal when **user clicks overlay** with indexNo === undefined. Also by putting this.props.children into modal, we were able to inject our own design components into by <ActionSheet><CancelButton></ActionSheet>

I believe this should come handy for other users too.