### PR TITLE
Fix console warning - useNativeDriver for animation

### DIFF
--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -11,7 +11,8 @@ class ActionSheet extends React.Component {
     tintColor: '#007AFF',
     buttonUnderlayColor: '#F4F4F4',
     onPress: () => {},
-    styles: {}
+    styles: {},
+    useNativeDriver: true
   }
 
   constructor (props) {
@@ -69,7 +70,7 @@ class ActionSheet extends React.Component {
       toValue: 0,
       duration: 250,
       easing: Easing.out(Easing.ease),
-      useNativeDriver: this.props.useNativeDriver === true
+      useNativeDriver: this.props.useNativeDriver
     }).start()
   }
 
@@ -77,7 +78,7 @@ class ActionSheet extends React.Component {
     Animated.timing(this.state.sheetAnim, {
       toValue: this.translateY,
       duration: 200,
-      useNativeDriver: this.props.useNativeDriver === true
+      useNativeDriver: this.props.useNativeDriver
     }).start(callback)
   }
 

--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -68,14 +68,16 @@ class ActionSheet extends React.Component {
     Animated.timing(this.state.sheetAnim, {
       toValue: 0,
       duration: 250,
-      easing: Easing.out(Easing.ease)
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: this.props.useNativeDriver || true
     }).start()
   }
 
   _hideSheet (callback) {
     Animated.timing(this.state.sheetAnim, {
       toValue: this.translateY,
-      duration: 200
+      duration: 200,
+      useNativeDriver: this.props.useNativeDriver || true
     }).start(callback)
   }
 

--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -69,7 +69,7 @@ class ActionSheet extends React.Component {
       toValue: 0,
       duration: 250,
       easing: Easing.out(Easing.ease),
-      useNativeDriver: this.props.useNativeDriver || true
+      useNativeDriver: this.props.useNativeDriver === true
     }).start()
   }
 
@@ -77,7 +77,7 @@ class ActionSheet extends React.Component {
     Animated.timing(this.state.sheetAnim, {
       toValue: this.translateY,
       duration: 200,
-      useNativeDriver: this.props.useNativeDriver || true
+      useNativeDriver: this.props.useNativeDriver === true
     }).start(callback)
   }
 


### PR DESCRIPTION
Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false.
You can override this by passing a `useNativeDriver` prop to the ActionSheet component