### PR TITLE
Solve useNativeDriver issue

### DIFF
--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -11,7 +11,9 @@ class ActionSheet extends React.Component {
     tintColor: '#007AFF',
     buttonUnderlayColor: '#F4F4F4',
     onPress: () => {},
-    styles: {}
+    styles: {},
+    useNativeDriver: true
+    
   }
 
   constructor (props) {
@@ -68,14 +70,16 @@ class ActionSheet extends React.Component {
     Animated.timing(this.state.sheetAnim, {
       toValue: 0,
       duration: 250,
-      easing: Easing.out(Easing.ease)
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: this.props.useNativeDriver
     }).start()
   }
 
   _hideSheet (callback) {
     Animated.timing(this.state.sheetAnim, {
       toValue: this.translateY,
-      duration: 200
+      duration: 200,
+      useNativeDriver: this.props.useNativeDriver
     }).start(callback)
   }
 


### PR DESCRIPTION
Transition animation does not work in android without useNativeDriver. So, there must be a prop for enabling useNativeDriver. Even the default prop should be useNativeDriver set to true.