### PR TITLE
Android: full screen overlay

### DIFF
--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -11,7 +11,8 @@ class ActionSheet extends React.Component {
     tintColor: '#007AFF',
     buttonUnderlayColor: '#F4F4F4',
     onPress: () => {},
-    styles: {}
+    styles: {},
+    statusBarTranslucent: false,
   }
 
   constructor (props) {
@@ -179,11 +180,13 @@ class ActionSheet extends React.Component {
   render () {
     const styles = this.styles
     const { visible, sheetAnim } = this.state
+    const { statusBarTranslucent } = this.props
     return (
       <Modal visible={visible}
         animationType='none'
         transparent
         onRequestClose={this._cancel}
+        statusBarTranslucent={statusBarTranslucent}
       >
         <View style={[styles.wrapper]}>
           <Text


### PR DESCRIPTION
# FEATURE

## Task Description

I need to cover whole screen with gray overlay. 
Now status bar is not covered on Android.

<img src="https://user-images.githubusercontent.com/13522469/94910815-e69f8780-04ad-11eb-9106-38bd672583bc.jpg" width="300"/>

## What was done

To give gray overlay ability to cover status bar I passed `statusBarTranslucent` ([doc](https://reactnative.dev/docs/modal#statusbartranslucent)) prop to `<Modal>`

## Result
<img src="https://user-images.githubusercontent.com/13522469/94910823-eacba500-04ad-11eb-84d2-55018ad09f5d.jpg" width="300"/>
