### PR TITLE
Added mandate `useNativeDriver`

### DIFF
--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -68,14 +68,16 @@ class ActionSheet extends React.Component {
     Animated.timing(this.state.sheetAnim, {
       toValue: 0,
       duration: 250,
-      easing: Easing.out(Easing.ease)
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: true,
     }).start()
   }
 
   _hideSheet (callback) {
     Animated.timing(this.state.sheetAnim, {
       toValue: this.translateY,
-      duration: 200
+      duration: 200,
+      useNativeDriver: true,
     }).start(callback)
   }
 


### PR DESCRIPTION
Latest React requires `useNativeDriver` prop for any animations. Absence of this prop throws warning which can be an error in future versions.

As translate animation supports by nativeDriver, so adding that to `true`